### PR TITLE
Disable irrelevant models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -32,5 +32,12 @@ clean-targets:         # directories to be removed by `dbt clean`
 # using the `{{ config(...) }}` macro.
 models:
   dbt_learn:
-    marts:
-      materialized: table
+    airbnb:
+      marts:
+        materialized: table
+    financials:
+      enabled: false
+    id_example:
+      enabled: false
+    metrics:
+      enabled: false


### PR DESCRIPTION
* Enabled: `airbnb`, `utils`
* Disabled: `financials`, `id_example`, `metrics`